### PR TITLE
Updated links description

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://syncanotest1-env.elasticbeanstalk.com/
 But it also has an dns alias to:
 https://v4.hydraengine.com/
 
-From there main page, you can navigate to:
+Use following links to see the docs, or to navigate to the first version of api:
 
 - docs [/docs/](https://syncanotest1-env.elasticbeanstalk.com/docs/) - swagger docs
 - api [/v1/](https://syncanotest1-env.elasticbeanstalk.com/v1/) - where is the first version of the api


### PR DESCRIPTION
Feel free to accept or reject based on your gut feeling.

The way it was written before, I understood it in a way, that there is actually a main page / home page hosted under https://syncanotest1-env.elasticbeanstalk.com/ and I tried to go there (expecting to see there links I could use to navigate to docs or v1) - there isn't which caused my frustration ;) 
I'm ok with not merging it, if I'm the only one who saw it that way.